### PR TITLE
add some bitcoin rust functions

### DIFF
--- a/specter_rust/README.md
+++ b/specter_rust/README.md
@@ -26,3 +26,12 @@ sudo cp target/debug/libspecter_rust.so /usr/lib
 ```
 dart examples/hello.dart
 ```
+
+## Creating bindings
+
+```
+dart pub get
+dart ffigen
+```
+
+Problems with llvm? For me this fixed the problem: `sudo ln /usr/lib/llvm-10/lib/libclang.so.1 /usr/lib/llvm-10/lib/libclang.so`

--- a/specter_rust/README.md
+++ b/specter_rust/README.md
@@ -1,15 +1,28 @@
 # specter_rust
 
-A new flutter plugin project.
+Specter Rust bindings for wallet functionality.
 
-## Getting Started
+## Building
 
-This project is a starting point for a Flutter
-[plug-in package](https://flutter.dev/developing-packages/),
-a specialized package that includes platform-specific implementation code for
-Android and/or iOS.
+First run:
 
-For help getting started with Flutter, view our
-[online documentation](https://flutter.dev/docs), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+```
+flutter pub get
+cd rust
+make init
+make bindings
+```
 
+Then for Android and iOS run `make all` or separately `make ios` and `make android`
+
+On Linux run `cargo build` and install the resulting library or make it somehow available for the system:
+
+```
+sudo cp target/debug/libspecter_rust.so /usr/lib
+```
+
+## Running dart example
+
+```
+dart examples/hello.dart
+```

--- a/specter_rust/examples/hello.dart
+++ b/specter_rust/examples/hello.dart
@@ -1,0 +1,38 @@
+import 'dart:ffi';
+import 'dart:io';
+import 'package:ffi/ffi.dart';
+import '../lib/specter_rust.dart';
+
+void main() {
+  print(SpecterRust.greet("Rust"));
+
+  // 16 bytes in hex makes 12 word recovery phrase
+  var entropy = "31313131313131313131313131313131";
+  var mnemonic = SpecterRust.mnemonic_from_entropy(entropy);
+  print(mnemonic);
+
+  try{
+    // invalid number of bytes should throw
+    print(SpecterRust.mnemonic_from_entropy("313131313131313131313131313131"));    
+  } catch (e) {
+    print("Error: $e");
+  }
+
+  // root key and fingerprint
+  var root = SpecterRust.mnemonic_to_root_key(mnemonic, "", "bitcoin");
+  var xprv = root["xprv"];
+  print(root);
+
+  // xpub at some path
+  var xpub = SpecterRust.derive_xpub(xprv, "m/84h/0h/0h");
+  print(xpub);
+
+  // default single-sig descriptor for bitcoin network
+  var desc = SpecterRust.default_descriptors(xprv, "bitcoin");
+  print(desc);
+
+  // first 10 addresses
+  var recv_desc = desc["recv_descriptor"];
+  var addresses = SpecterRust.derive_addresses(recv_desc, "bitcoin", 0, 10);
+  print(addresses);
+}

--- a/specter_rust/examples/hello.dart
+++ b/specter_rust/examples/hello.dart
@@ -19,8 +19,7 @@ void main() {
     print('Error: $e');
   }
 
-  // To derive root key from mnemonic we need to also pass bip39-password (empty string by default) and network:
-  // Network can be 'bitcoin', 'testnet', 'regtest' and 'signet'. We assume main bitcoin network here.
+  // To derive root key from mnemonic we need to also pass bip39-password (empty string by default).
   // The function returns a dict {'fingerprint': '4-bytes-in-hex', 'xprv': 'root private key string'}
   var root = SpecterRust.mnemonic_to_root_key(mnemonic, '');
   String xprv = root['xprv']; // this is our key
@@ -28,7 +27,8 @@ void main() {
   print(root);
   print('Fingerprint: $fgp');
 
-  // Derive master public key at some path
+  // Derive master public key at some path for current network:
+  // Network can be 'bitcoin', 'testnet', 'regtest' and 'signet'. We assume main bitcoin network here
   var xpub = SpecterRust.derive_xpub(xprv, "m/84'/0'/0'", 'bitcoin');
   print(xpub);
 

--- a/specter_rust/examples/hello.dart
+++ b/specter_rust/examples/hello.dart
@@ -22,12 +22,14 @@ void main() {
   // To derive root key from mnemonic we need to also pass bip39-password (empty string by default) and network:
   // Network can be 'bitcoin', 'testnet', 'regtest' and 'signet'. We assume main bitcoin network here.
   // The function returns a dict {'fingerprint': '4-bytes-in-hex', 'xprv': 'root private key string'}
-  var root = SpecterRust.mnemonic_to_root_key(mnemonic, '', 'bitcoin');
-  var xprv = root['xprv']; // this is our key
+  var root = SpecterRust.mnemonic_to_root_key(mnemonic, '');
+  String xprv = root['xprv']; // this is our key
+  String fgp = root['fingerprint'];
   print(root);
+  print('Fingerprint: $fgp');
 
   // Derive master public key at some path
-  var xpub = SpecterRust.derive_xpub(xprv, 'm/84h/0h/0h');
+  var xpub = SpecterRust.derive_xpub(xprv, "m/84'/0'/0'", 'bitcoin');
   print(xpub);
 
   // Construct default wallet descriptor.
@@ -43,4 +45,9 @@ void main() {
   var recv_desc = desc['recv_descriptor'];
   var addresses = SpecterRust.derive_addresses(recv_desc, 'bitcoin', 0, 10);
   print(addresses);
+
+  // get descriptor for account 3, type - nested segwit.
+  var nested_desc_acc_2 = SpecterRust.get_account_descriptors(xprv, 3, 'nested', 'bitcoin');
+  print(nested_desc_acc_2);
+
 }

--- a/specter_rust/examples/hello.dart
+++ b/specter_rust/examples/hello.dart
@@ -1,49 +1,46 @@
-import 'dart:ffi';
-import 'dart:io';
-import 'package:ffi/ffi.dart';
 import '../lib/specter_rust.dart';
 
 void main() {
-  print(SpecterRust.greet("Rust"));
+  print(SpecterRust.greet('Rust'));
 
   // First we need to generate entropy and convert it to hex.
   // 16 random bytes make 12-word mnemonic, 32 bytes makes 24-byte mnemonic.
   // Entropy should be generated from a secure random source.
   // Here 16 bytes are converted to hex and sent to rust to get back mnemonic:
-  var entropy = "31313131313131313131313131313131";
-  var mnemonic = SpecterRust.mnemonic_from_entropy(entropy);
+  String entropy = '31313131313131313131313131313131';
+  String mnemonic = SpecterRust.mnemonic_from_entropy(entropy);
   print(mnemonic);
 
   // If we pass invalid number of bytes or invalid hex string it will throw an exception
   try{
     // invalid number of bytes should throw
-    print(SpecterRust.mnemonic_from_entropy("313131313131313131313131313131"));    
+    print(SpecterRust.mnemonic_from_entropy('313131313131313131313131313131'));    
   } catch (e) {
-    print("Error: $e");
+    print('Error: $e');
   }
 
   // To derive root key from mnemonic we need to also pass bip39-password (empty string by default) and network:
-  // Network can be "bitcoin", "testnet", "regtest" and "signet". We assume main bitcoin network here.
-  // The function returns a dict {"fingerprint": "4-bytes-in-hex", "xprv": "root private key string"}
-  var root = SpecterRust.mnemonic_to_root_key(mnemonic, "", "bitcoin");
-  var xprv = root["xprv"]; // this is our key
+  // Network can be 'bitcoin', 'testnet', 'regtest' and 'signet'. We assume main bitcoin network here.
+  // The function returns a dict {'fingerprint': '4-bytes-in-hex', 'xprv': 'root private key string'}
+  var root = SpecterRust.mnemonic_to_root_key(mnemonic, '', 'bitcoin');
+  var xprv = root['xprv']; // this is our key
   print(root);
 
   // Derive master public key at some path
-  var xpub = SpecterRust.derive_xpub(xprv, "m/84h/0h/0h");
+  var xpub = SpecterRust.derive_xpub(xprv, 'm/84h/0h/0h');
   print(xpub);
 
   // Construct default wallet descriptor.
   // By default it constructs a single-sig segwit descriptor with path depending on the network.
-  // Returns a dict {"recv_descriptor": string, "change_descriptor": string}
+  // Returns a dict {'recv_descriptor': string, 'change_descriptor': string}
   // Recv descriptor is used to derive receiving addresses of the wallet, change descriptor is used for internal change addresses.
   // Address view in the app should display receiving addresses by default
   // (not sure if we need change addresses anywhere except verification of the transactions)
-  var desc = SpecterRust.default_descriptors(xprv, "bitcoin");
+  var desc = SpecterRust.get_default_descriptors(xprv, 'bitcoin');
   print(desc);
 
   // Derive first 10 addresses of the wallet for bitcoin network
-  var recv_desc = desc["recv_descriptor"];
-  var addresses = SpecterRust.derive_addresses(recv_desc, "bitcoin", 0, 10);
+  var recv_desc = desc['recv_descriptor'];
+  var addresses = SpecterRust.derive_addresses(recv_desc, 'bitcoin', 0, 10);
   print(addresses);
 }

--- a/specter_rust/lib/bindings.dart
+++ b/specter_rust/lib/bindings.dart
@@ -36,12 +36,10 @@ class SpecterRustBindings {
   ffi.Pointer<ffi.Int8> mnemonic_to_root_key(
     ffi.Pointer<ffi.Int8> mnemonic,
     ffi.Pointer<ffi.Int8> password,
-    ffi.Pointer<ffi.Int8> network,
   ) {
     return _mnemonic_to_root_key(
       mnemonic,
       password,
-      network,
     );
   }
 
@@ -54,10 +52,12 @@ class SpecterRustBindings {
   ffi.Pointer<ffi.Int8> derive_xpub(
     ffi.Pointer<ffi.Int8> root,
     ffi.Pointer<ffi.Int8> path,
+    ffi.Pointer<ffi.Int8> network,
   ) {
     return _derive_xpub(
       root,
       path,
+      network,
     );
   }
 
@@ -66,21 +66,24 @@ class SpecterRustBindings {
   late final _dart_derive_xpub _derive_xpub =
       _derive_xpub_ptr.asFunction<_dart_derive_xpub>();
 
-  ffi.Pointer<ffi.Int8> default_descriptors(
+  ffi.Pointer<ffi.Int8> get_descriptors(
     ffi.Pointer<ffi.Int8> root,
+    ffi.Pointer<ffi.Int8> path,
+    ffi.Pointer<ffi.Int8> scripttype,
     ffi.Pointer<ffi.Int8> network,
   ) {
-    return _default_descriptors(
+    return _get_descriptors(
       root,
+      path,
+      scripttype,
       network,
     );
   }
 
-  late final _default_descriptors_ptr =
-      _lookup<ffi.NativeFunction<_c_default_descriptors>>(
-          'default_descriptors');
-  late final _dart_default_descriptors _default_descriptors =
-      _default_descriptors_ptr.asFunction<_dart_default_descriptors>();
+  late final _get_descriptors_ptr =
+      _lookup<ffi.NativeFunction<_c_get_descriptors>>('get_descriptors');
+  late final _dart_get_descriptors _get_descriptors =
+      _get_descriptors_ptr.asFunction<_dart_get_descriptors>();
 
   ffi.Pointer<ffi.Int8> derive_addresses(
     ffi.Pointer<ffi.Int8> descriptor,
@@ -148,32 +151,36 @@ typedef _dart_mnemonic_from_entropy = ffi.Pointer<ffi.Int8> Function(
 typedef _c_mnemonic_to_root_key = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<ffi.Int8> mnemonic,
   ffi.Pointer<ffi.Int8> password,
-  ffi.Pointer<ffi.Int8> network,
 );
 
 typedef _dart_mnemonic_to_root_key = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<ffi.Int8> mnemonic,
   ffi.Pointer<ffi.Int8> password,
-  ffi.Pointer<ffi.Int8> network,
 );
 
 typedef _c_derive_xpub = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<ffi.Int8> root,
   ffi.Pointer<ffi.Int8> path,
+  ffi.Pointer<ffi.Int8> network,
 );
 
 typedef _dart_derive_xpub = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<ffi.Int8> root,
   ffi.Pointer<ffi.Int8> path,
-);
-
-typedef _c_default_descriptors = ffi.Pointer<ffi.Int8> Function(
-  ffi.Pointer<ffi.Int8> root,
   ffi.Pointer<ffi.Int8> network,
 );
 
-typedef _dart_default_descriptors = ffi.Pointer<ffi.Int8> Function(
+typedef _c_get_descriptors = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<ffi.Int8> root,
+  ffi.Pointer<ffi.Int8> path,
+  ffi.Pointer<ffi.Int8> scripttype,
+  ffi.Pointer<ffi.Int8> network,
+);
+
+typedef _dart_get_descriptors = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> root,
+  ffi.Pointer<ffi.Int8> path,
+  ffi.Pointer<ffi.Int8> scripttype,
   ffi.Pointer<ffi.Int8> network,
 );
 

--- a/specter_rust/lib/bindings.dart
+++ b/specter_rust/lib/bindings.dart
@@ -19,6 +19,88 @@ class SpecterRustBindings {
           lookup)
       : _lookup = lookup;
 
+  ffi.Pointer<ffi.Int8> mnemonic_from_entropy(
+    ffi.Pointer<ffi.Int8> hex_entropy,
+  ) {
+    return _mnemonic_from_entropy(
+      hex_entropy,
+    );
+  }
+
+  late final _mnemonic_from_entropy_ptr =
+      _lookup<ffi.NativeFunction<_c_mnemonic_from_entropy>>(
+          'mnemonic_from_entropy');
+  late final _dart_mnemonic_from_entropy _mnemonic_from_entropy =
+      _mnemonic_from_entropy_ptr.asFunction<_dart_mnemonic_from_entropy>();
+
+  ffi.Pointer<ffi.Int8> mnemonic_to_root_key(
+    ffi.Pointer<ffi.Int8> mnemonic,
+    ffi.Pointer<ffi.Int8> password,
+    ffi.Pointer<ffi.Int8> network,
+  ) {
+    return _mnemonic_to_root_key(
+      mnemonic,
+      password,
+      network,
+    );
+  }
+
+  late final _mnemonic_to_root_key_ptr =
+      _lookup<ffi.NativeFunction<_c_mnemonic_to_root_key>>(
+          'mnemonic_to_root_key');
+  late final _dart_mnemonic_to_root_key _mnemonic_to_root_key =
+      _mnemonic_to_root_key_ptr.asFunction<_dart_mnemonic_to_root_key>();
+
+  ffi.Pointer<ffi.Int8> derive_xpub(
+    ffi.Pointer<ffi.Int8> root,
+    ffi.Pointer<ffi.Int8> path,
+  ) {
+    return _derive_xpub(
+      root,
+      path,
+    );
+  }
+
+  late final _derive_xpub_ptr =
+      _lookup<ffi.NativeFunction<_c_derive_xpub>>('derive_xpub');
+  late final _dart_derive_xpub _derive_xpub =
+      _derive_xpub_ptr.asFunction<_dart_derive_xpub>();
+
+  ffi.Pointer<ffi.Int8> default_descriptors(
+    ffi.Pointer<ffi.Int8> root,
+    ffi.Pointer<ffi.Int8> network,
+  ) {
+    return _default_descriptors(
+      root,
+      network,
+    );
+  }
+
+  late final _default_descriptors_ptr =
+      _lookup<ffi.NativeFunction<_c_default_descriptors>>(
+          'default_descriptors');
+  late final _dart_default_descriptors _default_descriptors =
+      _default_descriptors_ptr.asFunction<_dart_default_descriptors>();
+
+  ffi.Pointer<ffi.Int8> derive_addresses(
+    ffi.Pointer<ffi.Int8> descriptor,
+    ffi.Pointer<ffi.Int8> network,
+    int start,
+    int end,
+  ) {
+    return _derive_addresses(
+      descriptor,
+      network,
+      start,
+      end,
+    );
+  }
+
+  late final _derive_addresses_ptr =
+      _lookup<ffi.NativeFunction<_c_derive_addresses>>('derive_addresses');
+  late final _dart_derive_addresses _derive_addresses =
+      _derive_addresses_ptr.asFunction<_dart_derive_addresses>();
+
   ffi.Pointer<ffi.Int8> rust_greeting(
     ffi.Pointer<ffi.Int8> to,
   ) {
@@ -54,6 +136,60 @@ class SpecterRustBindings {
   late final _dart_run_bitcoin_demo _run_bitcoin_demo =
       _run_bitcoin_demo_ptr.asFunction<_dart_run_bitcoin_demo>();
 }
+
+typedef _c_mnemonic_from_entropy = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> hex_entropy,
+);
+
+typedef _dart_mnemonic_from_entropy = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> hex_entropy,
+);
+
+typedef _c_mnemonic_to_root_key = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> mnemonic,
+  ffi.Pointer<ffi.Int8> password,
+  ffi.Pointer<ffi.Int8> network,
+);
+
+typedef _dart_mnemonic_to_root_key = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> mnemonic,
+  ffi.Pointer<ffi.Int8> password,
+  ffi.Pointer<ffi.Int8> network,
+);
+
+typedef _c_derive_xpub = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> root,
+  ffi.Pointer<ffi.Int8> path,
+);
+
+typedef _dart_derive_xpub = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> root,
+  ffi.Pointer<ffi.Int8> path,
+);
+
+typedef _c_default_descriptors = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> root,
+  ffi.Pointer<ffi.Int8> network,
+);
+
+typedef _dart_default_descriptors = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> root,
+  ffi.Pointer<ffi.Int8> network,
+);
+
+typedef _c_derive_addresses = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> descriptor,
+  ffi.Pointer<ffi.Int8> network,
+  ffi.Int32 start,
+  ffi.Int32 end,
+);
+
+typedef _dart_derive_addresses = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> descriptor,
+  ffi.Pointer<ffi.Int8> network,
+  int start,
+  int end,
+);
 
 typedef _c_rust_greeting = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<ffi.Int8> to,

--- a/specter_rust/lib/specter_rust.dart
+++ b/specter_rust/lib/specter_rust.dart
@@ -15,6 +15,67 @@ class SpecterRust {
         : DynamicLibrary.process();
   }
 
+  static String mnemonic_from_entropy(String hex_entropy){
+    final ptrEntropy = hex_entropy.toNativeUtf8(allocator: malloc);
+
+    final ptrResult = _bindings.mnemonic_from_entropy(ptrEntropy.cast<Int8>());
+
+    final result = ptrResult.cast<Utf8>().toDartString();
+    _bindings.rust_cstr_free(ptrResult);
+    malloc.free(ptrEntropy);
+    return result;
+  }
+  static String mnemonic_to_root_key(String mnemonic, String password, String network){
+    final ptrMnemonic = mnemonic.toNativeUtf8(allocator: malloc);
+    final ptrPassword = password.toNativeUtf8(allocator: malloc);
+    final ptrNetwork = network.toNativeUtf8(allocator: malloc);
+
+    final ptrResult = _bindings.mnemonic_to_root_key(ptrMnemonic.cast<Int8>(), ptrPassword.cast<Int8>(), ptrNetwork.cast<Int8>());
+    final result = ptrResult.cast<Utf8>().toDartString();
+    _bindings.rust_cstr_free(ptrResult);
+
+    malloc.free(ptrMnemonic);
+    malloc.free(ptrPassword);
+    malloc.free(ptrNetwork);
+    return result;
+  }
+  static String derive_xpub(String root, String path){
+    final ptrRoot = root.toNativeUtf8(allocator: malloc);
+    final ptrPath = path.toNativeUtf8(allocator: malloc);
+
+    final ptrResult = _bindings.derive_xpub(ptrRoot.cast<Int8>(), ptrPath.cast<Int8>());
+    final result = ptrResult.cast<Utf8>().toDartString();
+    _bindings.rust_cstr_free(ptrResult);
+
+    malloc.free(ptrRoot);
+    malloc.free(ptrPath);
+    return result;
+  }
+  static String default_descriptors(String root, String network){
+    final ptrRoot = root.toNativeUtf8(allocator: malloc);
+    final ptrNetwork = network.toNativeUtf8(allocator: malloc);
+
+    final ptrResult = _bindings.default_descriptors(ptrRoot.cast<Int8>(), ptrNetwork.cast<Int8>());
+    final result = ptrResult.cast<Utf8>().toDartString();
+    _bindings.rust_cstr_free(ptrResult);
+
+    malloc.free(ptrRoot);
+    malloc.free(ptrNetwork);
+    return result;
+  }
+  static String derive_addresses(String descriptor, String network, int start, int end){
+    final ptrDescriptor = descriptor.toNativeUtf8(allocator: malloc);
+    final ptrNetwork = network.toNativeUtf8(allocator: malloc);
+
+    final ptrResult = _bindings.derive_addresses(ptrDescriptor.cast<Int8>(), ptrNetwork.cast<Int8>(), start, end);
+    final result = ptrResult.cast<Utf8>().toDartString();
+    _bindings.rust_cstr_free(ptrResult);
+
+    malloc.free(ptrDescriptor);
+    malloc.free(ptrNetwork);
+    return result;
+  }
+
   /// Computes a greeting for the given name using the native function
   static String greet(String name) {
     // Allocate a native string holding argument in UTF-8

--- a/specter_rust/lib/specter_rust.dart
+++ b/specter_rust/lib/specter_rust.dart
@@ -1,18 +1,43 @@
 import 'dart:ffi';
 import 'dart:io';
+import 'dart:convert';
 import 'package:ffi/ffi.dart';
 import './bindings.dart';
 
 const DYNAMIC_LIBRARY_FILE_NAME = "libspecter_rust.so";
+
+class SpecterRustException implements Exception {
+  String _message = "Rust bindings error";
+  SpecterRustException([String message = "Rust bindings error"]){
+    this._message = message;
+  }
+  @override
+  String toString(){
+    return _message;
+  }
+}
 
 class SpecterRust {
   static final SpecterRustBindings _bindings =
       SpecterRustBindings(SpecterRust._loadLibrary());
 
   static DynamicLibrary _loadLibrary() {
+    if(Platform.isLinux){ // FIXME: dirty patch for development
+      return DynamicLibrary.open("../libspecter_rust.so");
+    }
     return Platform.isAndroid
         ? DynamicLibrary.open(DYNAMIC_LIBRARY_FILE_NAME)
         : DynamicLibrary.process();
+  }
+
+  // decodes json from rust side and returns a dict {"data": <data>}
+  // if error occured - throws SpecterRustException
+  static Map<String, dynamic> _decode_result(String result){
+    var data = jsonDecode(result);
+    if(data["status"] == "error"){
+      throw SpecterRustException(data["message"]);
+    }
+    return data;
   }
 
   static String mnemonic_from_entropy(String hex_entropy){
@@ -23,9 +48,10 @@ class SpecterRust {
     final result = ptrResult.cast<Utf8>().toDartString();
     _bindings.rust_cstr_free(ptrResult);
     malloc.free(ptrEntropy);
-    return result;
+    return _decode_result(result)["data"];
   }
-  static String mnemonic_to_root_key(String mnemonic, String password, String network){
+
+  static dynamic mnemonic_to_root_key(String mnemonic, String password, String network){
     final ptrMnemonic = mnemonic.toNativeUtf8(allocator: malloc);
     final ptrPassword = password.toNativeUtf8(allocator: malloc);
     final ptrNetwork = network.toNativeUtf8(allocator: malloc);
@@ -37,7 +63,7 @@ class SpecterRust {
     malloc.free(ptrMnemonic);
     malloc.free(ptrPassword);
     malloc.free(ptrNetwork);
-    return result;
+    return _decode_result(result)["data"];
   }
   static String derive_xpub(String root, String path){
     final ptrRoot = root.toNativeUtf8(allocator: malloc);
@@ -49,9 +75,9 @@ class SpecterRust {
 
     malloc.free(ptrRoot);
     malloc.free(ptrPath);
-    return result;
+    return _decode_result(result)["data"];
   }
-  static String default_descriptors(String root, String network){
+  static Map<String, dynamic> default_descriptors(String root, String network){
     final ptrRoot = root.toNativeUtf8(allocator: malloc);
     final ptrNetwork = network.toNativeUtf8(allocator: malloc);
 
@@ -61,9 +87,9 @@ class SpecterRust {
 
     malloc.free(ptrRoot);
     malloc.free(ptrNetwork);
-    return result;
+    return _decode_result(result)["data"];
   }
-  static String derive_addresses(String descriptor, String network, int start, int end){
+  static List<dynamic> derive_addresses(String descriptor, String network, int start, int end){
     final ptrDescriptor = descriptor.toNativeUtf8(allocator: malloc);
     final ptrNetwork = network.toNativeUtf8(allocator: malloc);
 
@@ -73,7 +99,7 @@ class SpecterRust {
 
     malloc.free(ptrDescriptor);
     malloc.free(ptrNetwork);
-    return result;
+    return _decode_result(result)["data"];
   }
 
   /// Computes a greeting for the given name using the native function

--- a/specter_rust/lib/specter_rust.dart
+++ b/specter_rust/lib/specter_rust.dart
@@ -7,9 +7,9 @@ import './bindings.dart';
 const DYNAMIC_LIBRARY_FILE_NAME = "libspecter_rust.so";
 
 class SpecterRustException implements Exception {
-  String _message = "Rust bindings error";
-  SpecterRustException([String message = "Rust bindings error"]){
-    this._message = message;
+  String _message = 'Rust bindings error';
+  SpecterRustException([String message = 'Rust bindings error']){
+    _message = message;
   }
   @override
   String toString(){
@@ -22,24 +22,28 @@ class SpecterRust {
       SpecterRustBindings(SpecterRust._loadLibrary());
 
   static DynamicLibrary _loadLibrary() {
-    if(Platform.isLinux){ // FIXME: dirty patch for development
-      return DynamicLibrary.open("../libspecter_rust.so");
-    }
-    return Platform.isAndroid
-        ? DynamicLibrary.open(DYNAMIC_LIBRARY_FILE_NAME)
-        : DynamicLibrary.process();
+    return Platform.isIOS
+        ? DynamicLibrary.process()
+        : DynamicLibrary.open(DYNAMIC_LIBRARY_FILE_NAME);
   }
 
   // decodes json from rust side and returns a dict {"data": <data>}
   // if error occured - throws SpecterRustException
   static Map<String, dynamic> _decode_result(String result){
     var data = jsonDecode(result);
-    if(data["status"] == "error"){
-      throw SpecterRustException(data["message"]);
+    if(data['status'] == 'error'){
+      throw SpecterRustException(data['message']);
     }
     return data;
   }
 
+  /// Converts hex-encoded entropy to mnemonic.
+  /// Entropy length must be 16 or 32 bytes, so [hex_entropy] should be 32 or 64 chars long.
+  /// 
+  /// ```dart
+  /// String mn = SpecterRust.mnemonic_from_entropy('31313131313131313131313131313131');
+  /// mn == 'couple maze era give basic obtain shadow change couple maze era glide';
+  /// ```
   static String mnemonic_from_entropy(String hex_entropy){
     final ptrEntropy = hex_entropy.toNativeUtf8(allocator: malloc);
 
@@ -48,9 +52,22 @@ class SpecterRust {
     final result = ptrResult.cast<Utf8>().toDartString();
     _bindings.rust_cstr_free(ptrResult);
     malloc.free(ptrEntropy);
-    return _decode_result(result)["data"];
+    return _decode_result(result)['data'];
   }
 
+  /// Converts 12 or 24-word [mnemonic] and [password] to Bitcoin root key.
+  /// 
+  /// [password] can be an arbitrary string, empty string should be used by default.
+  /// [network] can be 'bitcoin', 'testnet', 'signet' or 'regtest'.
+  /// Throws a [SpecterRustException] if [mnemonic] is invalid or network is unknown.
+  /// 
+  /// Returns an object {'fingerprint': '4-bytes-in-hex', 'xprv': 'root private key'}
+  /// 
+  /// ```dart
+  /// var root = SpecterRust.mnemonic_to_root_key('couple maze era give basic obtain shadow change couple maze era glide', '', 'bitcoin');
+  /// root['xprv'] == 'xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm'
+  /// root['fingerprint'] == '312e05df'
+  /// ```
   static dynamic mnemonic_to_root_key(String mnemonic, String password, String network){
     final ptrMnemonic = mnemonic.toNativeUtf8(allocator: malloc);
     final ptrPassword = password.toNativeUtf8(allocator: malloc);
@@ -63,10 +80,24 @@ class SpecterRust {
     malloc.free(ptrMnemonic);
     malloc.free(ptrPassword);
     malloc.free(ptrNetwork);
-    return _decode_result(result)["data"];
+    return _decode_result(result)['data'];
   }
-  static String derive_xpub(String root, String path){
-    final ptrRoot = root.toNativeUtf8(allocator: malloc);
+
+  /// Derives an extended public key from the [xprv] key using [path].
+  /// Returns an extended public key in Bitcoin Core descriptor format: `[fingerprint/derivation]xpub`.
+  /// 
+  /// Throws a [SpecterRustException] if [xprv] key is invalid or [path] is formatted incorrectly.
+  /// 
+  /// Examples for [path] argument: `'m/49h/1h/0h/2h'`, `"m/84'/0'/2'"`, `'m/123/456/45h'` etc.
+  /// Avoid mixing `h` and `'` in a derivation path.
+  /// 
+  /// 
+  /// ```dart
+  /// String xpub = SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/84h/0h/0h');
+  /// xpub == '[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H'
+  /// ```
+  static String derive_xpub(String xprv, String path){
+    final ptrRoot = xprv.toNativeUtf8(allocator: malloc);
     final ptrPath = path.toNativeUtf8(allocator: malloc);
 
     final ptrResult = _bindings.derive_xpub(ptrRoot.cast<Int8>(), ptrPath.cast<Int8>());
@@ -75,20 +106,41 @@ class SpecterRust {
 
     malloc.free(ptrRoot);
     malloc.free(ptrPath);
-    return _decode_result(result)["data"];
+    return _decode_result(result)['data'];
   }
-  static Map<String, dynamic> default_descriptors(String root, String network){
-    final ptrRoot = root.toNativeUtf8(allocator: malloc);
+
+  /// Gets default segwit single-key descriptors from [xprv] for a given [network]
+  /// [network] can be 'bitcoin', 'testnet', 'signet' or 'regtest'.
+  /// 
+  /// Throws a [SpecterRustException] if [xprv] is invalid or network is unknown.
+  /// 
+  /// Returns an object with wallet descriptors:
+  /// ```
+  /// {
+  ///   'recv_descriptor': 'wpkh([fgp/der]xpub/0/*)#checksum',
+  ///   'change_descriptor': 'wpkh([fgp/der]xpub/1/*)#checksum'
+  /// }
+  /// ```
+  static Map<String, dynamic> get_default_descriptors(String xprv, String network){
+    final ptrXprv = xprv.toNativeUtf8(allocator: malloc);
     final ptrNetwork = network.toNativeUtf8(allocator: malloc);
 
-    final ptrResult = _bindings.default_descriptors(ptrRoot.cast<Int8>(), ptrNetwork.cast<Int8>());
+    final ptrResult = _bindings.default_descriptors(ptrXprv.cast<Int8>(), ptrNetwork.cast<Int8>());
     final result = ptrResult.cast<Utf8>().toDartString();
     _bindings.rust_cstr_free(ptrResult);
 
-    malloc.free(ptrRoot);
+    malloc.free(ptrXprv);
     malloc.free(ptrNetwork);
-    return _decode_result(result)["data"];
+    return _decode_result(result)['data'];
   }
+
+  /// Derives addresses from [descriptor] for a given [network] with indexes from [start] to [end].
+  /// [network] can be 'bitcoin', 'testnet', 'signet' or 'regtest'.
+  /// 
+  /// Throws a [SpecterRustException] if [descriptor] is invalid, network is unknown or indexes are out of range.
+  /// Both [start] and [end] must be positive and less than 0x80000000.
+  /// 
+  /// Returns an list with addresses.
   static List<dynamic> derive_addresses(String descriptor, String network, int start, int end){
     final ptrDescriptor = descriptor.toNativeUtf8(allocator: malloc);
     final ptrNetwork = network.toNativeUtf8(allocator: malloc);
@@ -99,7 +151,7 @@ class SpecterRust {
 
     malloc.free(ptrDescriptor);
     malloc.free(ptrNetwork);
-    return _decode_result(result)["data"];
+    return _decode_result(result)['data'];
   }
 
   /// Computes a greeting for the given name using the native function
@@ -137,6 +189,6 @@ class SpecterRust {
   }
 
   static void sayHi() {
-    print("Hello from specter_rust (Dart side)");
+    print('Hello from specter_rust (Dart side)');
   }
 }

--- a/specter_rust/lib/specter_rust.dart
+++ b/specter_rust/lib/specter_rust.dart
@@ -58,33 +58,31 @@ class SpecterRust {
   /// Converts 12 or 24-word [mnemonic] and [password] to Bitcoin root key.
   /// 
   /// [password] can be an arbitrary string, empty string should be used by default.
-  /// [network] can be 'bitcoin', 'testnet', 'signet' or 'regtest'.
   /// Throws a [SpecterRustException] if [mnemonic] is invalid or network is unknown.
   /// 
   /// Returns an object {'fingerprint': '4-bytes-in-hex', 'xprv': 'root private key'}
   /// 
   /// ```dart
-  /// var root = SpecterRust.mnemonic_to_root_key('couple maze era give basic obtain shadow change couple maze era glide', '', 'bitcoin');
+  /// var root = SpecterRust.mnemonic_to_root_key('couple maze era give basic obtain shadow change couple maze era glide', '');
   /// root['xprv'] == 'xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm'
   /// root['fingerprint'] == '312e05df'
   /// ```
-  static dynamic mnemonic_to_root_key(String mnemonic, String password, String network){
+  static dynamic mnemonic_to_root_key(String mnemonic, String password){
     final ptrMnemonic = mnemonic.toNativeUtf8(allocator: malloc);
     final ptrPassword = password.toNativeUtf8(allocator: malloc);
-    final ptrNetwork = network.toNativeUtf8(allocator: malloc);
 
-    final ptrResult = _bindings.mnemonic_to_root_key(ptrMnemonic.cast<Int8>(), ptrPassword.cast<Int8>(), ptrNetwork.cast<Int8>());
+    final ptrResult = _bindings.mnemonic_to_root_key(ptrMnemonic.cast<Int8>(), ptrPassword.cast<Int8>());
     final result = ptrResult.cast<Utf8>().toDartString();
     _bindings.rust_cstr_free(ptrResult);
 
     malloc.free(ptrMnemonic);
     malloc.free(ptrPassword);
-    malloc.free(ptrNetwork);
     return _decode_result(result)['data'];
   }
 
-  /// Derives an extended public key from the [xprv] key using [path].
+  /// Derives an extended public key from the [xprv] key using [path] for [network].
   /// Returns an extended public key in Bitcoin Core descriptor format: `[fingerprint/derivation]xpub`.
+  /// [network] can be 'bitcoin', 'testnet', 'signet' or 'regtest'.
   /// 
   /// Throws a [SpecterRustException] if [xprv] key is invalid or [path] is formatted incorrectly.
   /// 
@@ -93,23 +91,25 @@ class SpecterRust {
   /// 
   /// 
   /// ```dart
-  /// String xpub = SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/84h/0h/0h');
+  /// String xpub = SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/84h/0h/0h', 'bitcoin');
   /// xpub == '[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H'
   /// ```
-  static String derive_xpub(String xprv, String path){
+  static String derive_xpub(String xprv, String path, String network){
     final ptrRoot = xprv.toNativeUtf8(allocator: malloc);
     final ptrPath = path.toNativeUtf8(allocator: malloc);
+    final ptrNetwork = network.toNativeUtf8(allocator: malloc);
 
-    final ptrResult = _bindings.derive_xpub(ptrRoot.cast<Int8>(), ptrPath.cast<Int8>());
+    final ptrResult = _bindings.derive_xpub(ptrRoot.cast<Int8>(), ptrPath.cast<Int8>(), ptrNetwork.cast<Int8>());
     final result = ptrResult.cast<Utf8>().toDartString();
     _bindings.rust_cstr_free(ptrResult);
 
     malloc.free(ptrRoot);
     malloc.free(ptrPath);
+    malloc.free(ptrNetwork);
     return _decode_result(result)['data'];
   }
 
-  /// Gets default segwit single-key descriptors from [xprv] for a given [network]
+  /// Get default segwit single-key descriptors from [xprv] for a given [network].
   /// [network] can be 'bitcoin', 'testnet', 'signet' or 'regtest'.
   /// 
   /// Throws a [SpecterRustException] if [xprv] is invalid or network is unknown.
@@ -122,14 +122,33 @@ class SpecterRust {
   /// }
   /// ```
   static Map<String, dynamic> get_default_descriptors(String xprv, String network){
+    String path = (network == 'bitcoin') ? "m/84'/0'/0'" : "m/84'/1'/0'";
+    return get_descriptors(xprv, path, 'segwit', network);
+  }
+
+  // Descriptor of type [scriptType] for [account] on [network]
+  static Map<String, dynamic> get_account_descriptors(String xprv, int account, String scriptType, String network){
+    String coinidx = (network == 'bitcoin') ? "0'" : "1'";
+    String accountidx = "$account'";
+    String purposeidx = (scriptType == 'segwit') ? "84'" : (scriptType == 'nested') ? "49'" : "44'";
+    String path = 'm/$purposeidx/$coinidx/$accountidx';
+    return get_descriptors(xprv, path, scriptType, network);
+  }
+
+  /// Arbitrary descriptor for arbitrary derivation path. [path] - derivation path, [scripttype] - 'segwit', 'nested' or 'legacy'.
+  static Map<String, dynamic> get_descriptors(String xprv, String path, String scripttype, String network){
     final ptrXprv = xprv.toNativeUtf8(allocator: malloc);
+    final ptrPath = path.toNativeUtf8(allocator: malloc);
+    final ptrScripttype = scripttype.toNativeUtf8(allocator: malloc);
     final ptrNetwork = network.toNativeUtf8(allocator: malloc);
 
-    final ptrResult = _bindings.default_descriptors(ptrXprv.cast<Int8>(), ptrNetwork.cast<Int8>());
+    final ptrResult = _bindings.get_descriptors(ptrXprv.cast<Int8>(), ptrPath.cast<Int8>(), ptrScripttype.cast<Int8>(), ptrNetwork.cast<Int8>());
     final result = ptrResult.cast<Utf8>().toDartString();
     _bindings.rust_cstr_free(ptrResult);
 
     malloc.free(ptrXprv);
+    malloc.free(ptrPath);
+    malloc.free(ptrScripttype);
     malloc.free(ptrNetwork);
     return _decode_result(result)['data'];
   }

--- a/specter_rust/rust/Cargo.toml
+++ b/specter_rust/rust/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 bip39 = "1.0.1"
-miniscript = "5.1.0"
-bitcoin = { version="0.26.0", features=["base64"] }
+miniscript = "6.0.1"
+bitcoin = { version="0.27.1", features=["base64"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"

--- a/specter_rust/rust/Cargo.toml
+++ b/specter_rust/rust/Cargo.toml
@@ -14,4 +14,5 @@ crate-type = ["staticlib", "cdylib"]
 bip39 = "1.0.1"
 miniscript = "5.1.0"
 bitcoin = { version="0.26.0", features=["base64"] }
-
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.73"

--- a/specter_rust/rust/src/lib.rs
+++ b/specter_rust/rust/src/lib.rs
@@ -1,7 +1,180 @@
+#![allow(unused_imports)]
+
 use std::os::raw::{c_char};
 use std::ffi::{CString, CStr};
+use std::str::FromStr;
+
+use bip39::Mnemonic;
+use bitcoin::hashes::hex::FromHex;
+use bitcoin::{
+    secp256k1::{Message, Secp256k1},
+    network::constants::Network,
+    util::bip32::{
+        ExtendedPrivKey, ExtendedPubKey, DerivationPath
+    },
+    util::bip143,
+    util::psbt::PartiallySignedTransaction,
+    base64,
+    consensus::encode::{serialize, deserialize},
+    blockdata::script::Script,
+    blockdata::transaction::SigHashType
+};
+use miniscript::{
+    DescriptorTrait, DescriptorPublicKey, TranslatePk2,
+    psbt::{extract, finalize}
+};
+use serde_json::json;
 
 mod bitcoin_demo;
+
+// ========================= MACROS ===========================
+
+macro_rules! err {
+    ($expression:expr) => {
+        match $expression {
+            Ok(a) => a,
+            Err(e) => {
+                return CString::new(json!({
+                    "status": "error",
+                    "message": format!("{}", e)
+                }).to_string()).unwrap().into_raw();
+            }
+        }
+    };
+}
+
+macro_rules! ok {
+    ($x:expr) => {
+        {
+            CString::new(json!({
+                "status": "success",
+                "data": $x
+            }).to_string()).unwrap().into_raw()
+        }
+    };
+}
+
+macro_rules! result {
+    ($x:expr) => {
+        {
+            ok!(err!($x).to_string())
+        }
+    };
+}
+
+macro_rules! cstr {
+    ($x:expr) => {
+        {
+            err!(unsafe { CStr::from_ptr($x) }.to_str())
+        }
+    };
+}
+
+// ========================= BITCOIN ===========================
+
+#[no_mangle]
+pub extern fn mnemonic_from_entropy(hex_entropy: *const c_char) -> *mut c_char {
+    let hex_entropy = cstr!(hex_entropy);
+    let entropy = err!(Vec::<u8>::from_hex(&hex_entropy));
+    result!(Mnemonic::from_entropy(&entropy))
+}
+
+#[no_mangle]
+pub extern fn mnemonic_to_root_key(mnemonic: *const c_char, password: *const c_char, network: *const c_char) -> *mut c_char {
+    let network = cstr!(network);
+    let mnemonic = cstr!(mnemonic);
+    let password = cstr!(password);
+
+    let network = err!(network.parse::<Network>());
+    let mnemonic = err!(Mnemonic::parse(mnemonic));
+    let seed = mnemonic.to_seed(password);
+
+    // generate root bip-32 key from seed
+    let root = err!(ExtendedPrivKey::new_master(network, &seed));
+
+    let secp_ctx = Secp256k1::new();
+    let fingerprint = root.fingerprint(&secp_ctx);
+    ok!(json!({
+        "fingerprint": fingerprint.to_string(),
+        "xprv": root.to_string()
+    }))
+}
+
+#[no_mangle]
+pub extern fn derive_xpub(root: *const c_char, path: *const c_char) -> *mut c_char {
+    let path = cstr!(path);
+    let root = cstr!(root);
+
+    let root = err!(ExtendedPrivKey::from_str(root));
+    let derivation = err!(DerivationPath::from_str(path));
+
+    // child private key
+    let secp_ctx = Secp256k1::new();
+    let fingerprint = root.fingerprint(&secp_ctx);
+    let child = err!(root.derive_priv(&secp_ctx, &derivation));
+    let xpub = ExtendedPubKey::from_private(&secp_ctx, &child);
+    let key = format!("[{}{}]{}", fingerprint, &path[1..], xpub);
+    ok!(key)
+}
+
+#[no_mangle]
+pub extern fn default_descriptors(root: *const c_char, network: *const c_char) -> *mut c_char {
+    let network = cstr!(network);
+    let root = cstr!(root);
+
+    let network = err!(network.parse::<Network>());
+    let root = err!(ExtendedPrivKey::from_str(root));
+
+    let path = match network {
+        Network::Bitcoin => {
+            "m/84h/0h/0h"
+        }
+        _ => {
+            "m/84h/1h/0h"
+        }
+    };
+    let derivation = err!(DerivationPath::from_str(path));
+
+    let secp_ctx = Secp256k1::new();
+
+    // child private key
+    let fingerprint = root.fingerprint(&secp_ctx);
+    let child = err!(root.derive_priv(&secp_ctx, &derivation));
+    let xpub = ExtendedPubKey::from_private(&secp_ctx, &child);
+
+    let key = format!("[{}{}]{}", fingerprint, &path[1..], xpub);
+
+    let recv_desc = err!(miniscript::Descriptor::<DescriptorPublicKey>::from_str(
+        &format!("wpkh({}/0/*)", key)
+    ));
+    let change_desc = err!(miniscript::Descriptor::<DescriptorPublicKey>::from_str(
+        &format!("wpkh({}/0/*)", key)
+    ));
+    ok!(json!({
+        "recv_descriptor": recv_desc.to_string(),
+        "change_descriptor": change_desc.to_string(),
+    }))
+}
+
+#[no_mangle]
+pub extern fn derive_addresses(descriptor: *const c_char, network: *const c_char, start: u32, end: u32) -> *mut c_char {
+    let descriptor = cstr!(descriptor);
+    let network = cstr!(network);
+    let descriptor = err!(miniscript::Descriptor::<DescriptorPublicKey>::from_str(descriptor));
+    let network = err!(network.parse::<Network>());
+
+    let secp_ctx = Secp256k1::new();
+    let mut addr = Vec::new();
+    for idx in start..end{
+        let a = err!(err!(descriptor.derive(idx)
+            .translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx)))
+            .address(network)).to_string();
+        addr.push(a);
+    }
+    ok!(json!(addr))
+}
+
+// ========================= OTHER ===========================
 
 #[no_mangle]
 pub extern fn rust_greeting(to: *const c_char) -> *mut c_char {


### PR DESCRIPTION
All functions from Rust side return a json in format like this: https://github.com/omniti-labs/jsend
On success json looks like:
```
{ "status": "success", "data": <data here> }
```
If something didn't work the result will contain an error message:
```
{"status": "error", "message": "human-readable error"}
```
Maybe makes sense to use https://pub.dev/packages/jsend to parse it.

Adds the following functions to the rust part:
- `mnemonic_from_entropy(hex_entropy)` - pass hex-string of 16 or 32 bytes of entropy to convert it to mnemonic
- `mnemonic_to_root_key(mnemonic, password, network)` - password can be an empty string, network is `bitcoin`, `testnet`, `regtest` or `signet`.
- `derive_xpub(root_key, path)` - derives xpub, for example `derive_xpub("xprvblahblahbla...", "m/84h/0h/0h")`
- `default_descriptors(root_key, network)` - returns receive and change descriptors for default wallet (`wpkh`)
- `derive_addresses(descriptor, network, start, end)` - returns an array of addresses for descriptor, starting from `start` up to `end`.

Not sure if I did the bindings correctly, especially `derive_addresses` function.
I still need to figure out how to compile and run the project in order to test the bindings...