### PR TITLE
Add rust tests, descriptor parsing, tx parsing and signing functionality 

### DIFF
--- a/specter_rust/README.md
+++ b/specter_rust/README.md
@@ -31,7 +31,7 @@ dart examples/hello.dart
 
 ```
 dart pub get
-dart ffigen
+dart run ffigen
 ```
 
 Problems with llvm? For me this fixed the problem: `sudo ln /usr/lib/llvm-10/lib/libclang.so.1 /usr/lib/llvm-10/lib/libclang.so`

--- a/specter_rust/lib/bindings.dart
+++ b/specter_rust/lib/bindings.dart
@@ -121,6 +121,38 @@ class SpecterRustBindings {
   late final _dart_parse_descriptor _parse_descriptor =
       _parse_descriptor_ptr.asFunction<_dart_parse_descriptor>();
 
+  ffi.Pointer<ffi.Int8> parse_transaction(
+    ffi.Pointer<ffi.Int8> psbt,
+    ffi.Pointer<ffi.Int8> _wallets,
+    ffi.Pointer<ffi.Int8> _network,
+  ) {
+    return _parse_transaction(
+      psbt,
+      _wallets,
+      _network,
+    );
+  }
+
+  late final _parse_transaction_ptr =
+      _lookup<ffi.NativeFunction<_c_parse_transaction>>('parse_transaction');
+  late final _dart_parse_transaction _parse_transaction =
+      _parse_transaction_ptr.asFunction<_dart_parse_transaction>();
+
+  ffi.Pointer<ffi.Int8> sign_transaction(
+    ffi.Pointer<ffi.Int8> psbt,
+    ffi.Pointer<ffi.Int8> root,
+  ) {
+    return _sign_transaction(
+      psbt,
+      root,
+    );
+  }
+
+  late final _sign_transaction_ptr =
+      _lookup<ffi.NativeFunction<_c_sign_transaction>>('sign_transaction');
+  late final _dart_sign_transaction _sign_transaction =
+      _sign_transaction_ptr.asFunction<_dart_sign_transaction>();
+
   ffi.Pointer<ffi.Int8> rust_greeting(
     ffi.Pointer<ffi.Int8> to,
   ) {
@@ -225,6 +257,28 @@ typedef _dart_parse_descriptor = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<ffi.Int8> descriptor,
   ffi.Pointer<ffi.Int8> root,
   ffi.Pointer<ffi.Int8> network,
+);
+
+typedef _c_parse_transaction = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> psbt,
+  ffi.Pointer<ffi.Int8> _wallets,
+  ffi.Pointer<ffi.Int8> _network,
+);
+
+typedef _dart_parse_transaction = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> psbt,
+  ffi.Pointer<ffi.Int8> _wallets,
+  ffi.Pointer<ffi.Int8> _network,
+);
+
+typedef _c_sign_transaction = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> psbt,
+  ffi.Pointer<ffi.Int8> root,
+);
+
+typedef _dart_sign_transaction = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> psbt,
+  ffi.Pointer<ffi.Int8> root,
 );
 
 typedef _c_rust_greeting = ffi.Pointer<ffi.Int8> Function(

--- a/specter_rust/lib/bindings.dart
+++ b/specter_rust/lib/bindings.dart
@@ -104,6 +104,23 @@ class SpecterRustBindings {
   late final _dart_derive_addresses _derive_addresses =
       _derive_addresses_ptr.asFunction<_dart_derive_addresses>();
 
+  ffi.Pointer<ffi.Int8> parse_descriptor(
+    ffi.Pointer<ffi.Int8> descriptor,
+    ffi.Pointer<ffi.Int8> root,
+    ffi.Pointer<ffi.Int8> network,
+  ) {
+    return _parse_descriptor(
+      descriptor,
+      root,
+      network,
+    );
+  }
+
+  late final _parse_descriptor_ptr =
+      _lookup<ffi.NativeFunction<_c_parse_descriptor>>('parse_descriptor');
+  late final _dart_parse_descriptor _parse_descriptor =
+      _parse_descriptor_ptr.asFunction<_dart_parse_descriptor>();
+
   ffi.Pointer<ffi.Int8> rust_greeting(
     ffi.Pointer<ffi.Int8> to,
   ) {
@@ -196,6 +213,18 @@ typedef _dart_derive_addresses = ffi.Pointer<ffi.Int8> Function(
   ffi.Pointer<ffi.Int8> network,
   int start,
   int end,
+);
+
+typedef _c_parse_descriptor = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> descriptor,
+  ffi.Pointer<ffi.Int8> root,
+  ffi.Pointer<ffi.Int8> network,
+);
+
+typedef _dart_parse_descriptor = ffi.Pointer<ffi.Int8> Function(
+  ffi.Pointer<ffi.Int8> descriptor,
+  ffi.Pointer<ffi.Int8> root,
+  ffi.Pointer<ffi.Int8> network,
 );
 
 typedef _c_rust_greeting = ffi.Pointer<ffi.Int8> Function(

--- a/specter_rust/lib/specter_rust.dart
+++ b/specter_rust/lib/specter_rust.dart
@@ -206,6 +206,27 @@ class SpecterRust {
     return _decode_result(result)['data'];
   }
 
+  /// Parses wallet descriptor and returns a summary:
+  /// { change_descriptor, recv_descriptor, policy, type, keys, mine }
+  static Map<String, dynamic> parse_descriptor(
+    String descriptor, String xprv, String network){
+
+    final ptrDescriptor = descriptor.toNativeUtf8(allocator: malloc);
+    final ptrXprv = xprv.toNativeUtf8(allocator: malloc);
+    final ptrNetwork = network.toNativeUtf8(allocator: malloc);
+
+    final ptrResult = _bindings.parse_descriptor(
+        ptrDescriptor.cast<Int8>(), ptrXprv.cast<Int8>(), ptrNetwork.cast<Int8>());
+    final result = ptrResult.cast<Utf8>().toDartString();
+    _bindings.rust_cstr_free(ptrResult);
+
+    malloc.free(ptrDescriptor);
+    malloc.free(ptrXprv);
+    malloc.free(ptrNetwork);
+    return _decode_result(result)['data'];
+
+  }
+
   /// Computes a greeting for the given name using the native function
   static String greet(String name) {
     // Allocate a native string holding argument in UTF-8

--- a/specter_rust/lib/specter_rust.dart
+++ b/specter_rust/lib/specter_rust.dart
@@ -4,7 +4,7 @@ import 'dart:convert';
 import 'package:ffi/ffi.dart';
 import './bindings.dart';
 
-const DYNAMIC_LIBRARY_FILE_NAME = "libspecter_rust.so";
+const DYNAMIC_LIBRARY_FILE_NAME = 'libspecter_rust.so';
 
 class SpecterRustException implements Exception {
   String _message = 'Rust bindings error';
@@ -190,6 +190,9 @@ class SpecterRust {
   /// Returns an list with addresses.
   static List<dynamic> derive_addresses(
       String descriptor, String network, int start, int end) {
+    if(start < 0 || end < 0 || start >= 0x80000000 || end >= 0x80000000){
+      throw SpecterRustException('indexes must be in range [0, 0x80000000)');
+    }
     final ptrDescriptor = descriptor.toNativeUtf8(allocator: malloc);
     final ptrNetwork = network.toNativeUtf8(allocator: malloc);
 

--- a/specter_rust/lib/specter_rust.dart
+++ b/specter_rust/lib/specter_rust.dart
@@ -227,7 +227,10 @@ class SpecterRust {
 
   }
 
-  // parses psbt transaction
+  /// Parses psbt transaction, checks if inputs and outputs belong to any of the wallets.
+  /// Returns metadata for display as a dict. Content: inputs, outputs, fee.
+  /// Every input and output has the following info: { address, value in satoshi, wallets owning it }.
+  /// wallets is a list of indexes of the wallets owning this input or output (normally either one element or empty list).
   static Map<String, dynamic> parse_transaction(
     String psbt, List<dynamic> wallets, String network){
 
@@ -247,7 +250,7 @@ class SpecterRust {
     return _decode_result(result)['data'];
   }
 
-  // parses psbt transaction
+  /// Signs psbt transaction - pass base64 tx string and root key, get back signed transaction.
   static String sign_transaction(
     String psbt, String xprv){
 

--- a/specter_rust/lib/specter_rust.dart
+++ b/specter_rust/lib/specter_rust.dart
@@ -227,6 +227,43 @@ class SpecterRust {
 
   }
 
+  // parses psbt transaction
+  static Map<String, dynamic> parse_transaction(
+    String psbt, List<dynamic> wallets, String network){
+
+    String wallets_json = jsonEncode(wallets);
+    final ptrPSBT = psbt.toNativeUtf8(allocator: malloc);
+    final ptrWallets = wallets_json.toNativeUtf8(allocator: malloc);
+    final ptrNetwork = network.toNativeUtf8(allocator: malloc);
+
+    final ptrResult = _bindings.parse_transaction(
+        ptrPSBT.cast<Int8>(), ptrWallets.cast<Int8>(), ptrNetwork.cast<Int8>());
+    final result = ptrResult.cast<Utf8>().toDartString();
+    _bindings.rust_cstr_free(ptrResult);
+
+    malloc.free(ptrPSBT);
+    malloc.free(ptrWallets);
+    malloc.free(ptrNetwork);
+    return _decode_result(result)['data'];
+  }
+
+  // parses psbt transaction
+  static String sign_transaction(
+    String psbt, String xprv){
+
+    final ptrPSBT = psbt.toNativeUtf8(allocator: malloc);
+    final ptrXprv = xprv.toNativeUtf8(allocator: malloc);
+
+    final ptrResult = _bindings.sign_transaction(
+        ptrPSBT.cast<Int8>(), ptrXprv.cast<Int8>());
+    final result = ptrResult.cast<Utf8>().toDartString();
+    _bindings.rust_cstr_free(ptrResult);
+
+    malloc.free(ptrPSBT);
+    malloc.free(ptrXprv);
+    return _decode_result(result)['data'];
+  }
+
   /// Computes a greeting for the given name using the native function
   static String greet(String name) {
     // Allocate a native string holding argument in UTF-8

--- a/specter_rust/rust/Cargo.toml
+++ b/specter_rust/rust/Cargo.toml
@@ -13,6 +13,6 @@ crate-type = ["staticlib", "cdylib"]
 [dependencies]
 bip39 = "1.0.1"
 miniscript = "6.0.1"
-bitcoin = { version="0.27.1", features=["base64"] }
+bitcoin = { version="0.27.1", features=["base64", "use-serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.73"

--- a/specter_rust/rust/src/lib.rs
+++ b/specter_rust/rust/src/lib.rs
@@ -188,7 +188,8 @@ pub extern fn parse_descriptor(descriptor: *const c_char, root: *const c_char, n
     let descriptor = cstr!(descriptor);
     // TODO: fix for other branch indexes
     let arr: Vec<&str> = descriptor.split("#").collect();
-    let descriptor = arr[0].replace("/{0,1}/","/0/");
+    // {0,1} is used in Specter, <0;1> might be used in Core in the future
+    let descriptor = arr[0].replace("/{0,1}/","/0/").replace("/<0;1>/", "/0/");
     let change_desc = descriptor.replace("/0/*", "/1/*");
     let network = cstr!(network);
     let root = cstr!(root);

--- a/specter_rust/rust/src/lib.rs
+++ b/specter_rust/rust/src/lib.rs
@@ -4,16 +4,17 @@ use std::os::raw::{c_char};
 use std::ffi::{CString, CStr};
 use std::str::FromStr;
 
+use std::collections::BTreeMap;
 use bip39::Mnemonic;
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::{
-    secp256k1::{Message, Secp256k1},
+    secp256k1::{self, Message, Secp256k1},
     network::constants::Network,
     util::bip32::{
-        ExtendedPrivKey, ExtendedPubKey, DerivationPath
+        ExtendedPrivKey, ExtendedPubKey, KeySource, DerivationPath, ChildNumber
     },
-    util::bip143,
-    util::psbt::PartiallySignedTransaction,
+    util::{ bip143, ecdsa::PublicKey, address::Address },
+    util::psbt::{self, PartiallySignedTransaction},
     base64,
     consensus::encode::{serialize, deserialize},
     blockdata::script::Script,
@@ -25,7 +26,8 @@ use miniscript::{
     policy::Liftable,
     psbt::{extract, finalize},
 };
-use serde_json::json;
+use serde_json::{json, Value};
+use serde::{Deserialize, Serialize};
 
 mod bitcoin_demo;
 
@@ -269,12 +271,106 @@ pub extern fn parse_descriptor(descriptor: *const c_char, root: *const c_char, n
     }))
 }
 
+
+#[derive(Debug, Serialize, Deserialize)]
+struct WJSON {
+    pub recv_descriptor: String,
+    pub change_descriptor: String,
+}
+
+enum Scope {
+    Inp(psbt::Input),
+    Out(psbt::Output, Script),
+}
+
+struct Wallet {
+    recv_descriptor: miniscript::Descriptor::<DescriptorPublicKey>,
+    change_descriptor: miniscript::Descriptor::<DescriptorPublicKey>,
+}
+
+impl Wallet {
+    fn check_script<C: secp256k1::Verification>(&self, secp_ctx: &Secp256k1<C>, bip32_derivation: &BTreeMap<PublicKey, KeySource>, script_pubkey: &Script) -> bool{
+        for (_pubkey, derivation) in bip32_derivation.iter() {
+            // TODO: fix for generic descriptors
+            let der = derivation.1.clone();
+            let last_idx : u32 = der[der.len()-1].into();
+            let change_idx : u32 = der[der.len()-2].into();
+            let mut desc = &self.recv_descriptor;
+            if change_idx == 1 {
+                desc = &self.change_descriptor;
+            };
+            let desc = desc.derive(last_idx).translate_pk2(|xpk| xpk.derive_public_key(&secp_ctx)).unwrap();
+            return &desc.script_pubkey() == script_pubkey;
+        }
+        false
+    }
+
+    fn owns<C: secp256k1::Verification>(&self, secp_ctx: &Secp256k1<C>, scope: &Scope) -> bool{
+        match scope {
+            Scope::Inp(inp) => {
+                let sc = inp.witness_utxo.as_ref().unwrap().script_pubkey.clone();
+                return self.check_script(secp_ctx, &inp.bip32_derivation, &sc);
+            }
+            Scope::Out(out, sc) => {
+                return self.check_script(secp_ctx, &out.bip32_derivation, &sc);
+            }
+        }
+    }
+}
+
 #[no_mangle]
-pub extern fn parse_transaction(psbt: *const c_char, _wallets: *const c_char, _network: *const c_char) -> *mut c_char{
+pub extern fn parse_transaction(psbt: *const c_char, wallets: *const c_char, network: *const c_char) -> *mut c_char{
+    let wallets = cstr!(wallets);
+    let network = cstr!(network);
     let psbt = cstr!(psbt);
+    let network = err!(network.parse::<Network>());
+    let wallets : Vec<WJSON> = err!(serde_json::from_str(wallets));
+    let wallets : Vec<Wallet> = wallets.iter().map(|w| {
+        Wallet {
+            recv_descriptor: miniscript::Descriptor::<DescriptorPublicKey>::from_str(&w.recv_descriptor).unwrap(),
+            change_descriptor: miniscript::Descriptor::<DescriptorPublicKey>::from_str(&w.change_descriptor).unwrap(),
+        }
+    }).collect();
     let raw = err!(base64::decode(psbt));
     let psbt:PartiallySignedTransaction = err!(deserialize(&raw));
-    ok!(json!(&psbt))
+    // parse inputs and outputs
+    let secp_ctx = Secp256k1::new();
+    let mut fee = 0;
+    let ins : Vec<Value> = psbt.inputs.iter().map(|inp| {
+        let utxo = inp.witness_utxo.clone().unwrap();
+        fee += utxo.value;
+        json!({
+            "value": utxo.value,
+            "address": Address::from_script(&utxo.script_pubkey, network).unwrap(),
+            "wallets": wallets.iter().enumerate().map(|(i, w)| {
+                if w.owns(&secp_ctx, &Scope::Inp(inp.clone())){
+                    i as i32
+                } else {
+                    -1
+                }
+            }).filter(|i| i>=&0).collect::<Vec<i32>>(),
+        })
+    }).collect();
+    let outs : Vec<Value> = psbt.outputs.iter().enumerate().map(|(i, out)| {
+        let utxo = psbt.global.unsigned_tx.output[i].clone();
+        fee -= utxo.value;
+        json!({
+            "value": utxo.value,
+            "address": Address::from_script(&utxo.script_pubkey, network).unwrap(),
+            "wallets": wallets.iter().enumerate().map(|(i, w)| {
+                if w.owns(&secp_ctx, &Scope::Out(out.clone(), utxo.script_pubkey.clone())) {
+                    i as i32
+                } else {
+                    -1
+                }
+            }).filter(|i| i>=&0).collect::<Vec<i32>>(),
+        })
+    }).collect();
+    ok!(json!({
+        "inputs": ins,
+        "outputs": outs,
+        "fee": fee,
+    }))
 }
 
 #[no_mangle]

--- a/specter_rust/test/specter_rust_test.dart
+++ b/specter_rust/test/specter_rust_test.dart
@@ -204,6 +204,7 @@ void main() {
   });
 
   test('parse_descriptor', () {
+    // TODO: more tests
     String root = 'xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm';
     expect(
       SpecterRust.parse_descriptor("wsh(sortedmulti(1,[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/0/*))", root, 'bitcoin'),
@@ -219,10 +220,30 @@ void main() {
         'policy': '1 of 2 multisig',
       }
     );
-    // TODO: more tests
   });
-  // TODO: parse_transaction
-  // TODO: sign_transaction
+
+  test('parse_transaction', () {
+    // TODO: more tests (malformed, multiwallet, custom sighashes)
+    String root = 'xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm';
+    String psbt = 'cHNidP8BAH0CAAAAAfDz5mfHe0eBUAbazbcr7we9vpo2+hxiiWxGnPMkwLj+AAAAAAD+////AoCWmAAAAAAAFgAUM0kk6vRugG6Gs1N6EvgVlQMNc6fNSV0FAAAAACIAIPS/xbC8hbQfm15NlCSFLrdSVY0nsQIaJQ5X9R3zbefg1gAAAAABAH0CAAAAAcGtDHVoTFXHMZZJSA8zJ362P1ZLvmPuyhqdb7k6bOWbAAAAAAD+////AgDh9QUAAAAAIgAgjG8duakkjuNk3IzbiMKr91QjvUUtT2/1Li4LXzxgBPlnEBAkAQAAABYAFKBfKSQYEBYs5aYwucljg4mW0OsuAAAAAAEBKwDh9QUAAAAAIgAgjG8duakkjuNk3IzbiMKr91QjvUUtT2/1Li4LXzxgBPkBBUdRIQJd2kbjIJNo6aA3muoxjqa3bietbgN7lqrbjMbPzScO9iEDqYT05aiCopyrT5gt8oIc8sM/JXv9nFbBVL5GR10uiptSriIGAl3aRuMgk2jpoDea6jGOprduJ61uA3uWqtuMxs/NJw72HLCvWO0wAACAAQAAgAAAAIACAACAAAAAAAAAAAAiBgOphPTlqIKinKtPmC3yghzywz8le/2cVsFUvkZHXS6KmxgxLgXfMAAAgAEAAIAAAACAAAAAAAAAAAAAAAEBR1EhAnV6ftmjyLLCxBLL3f1uGwzJDKTj+Lsu8TP7hdodCyVnIQMH1JWAelJ0hprNcX2+JnHw2b5yN4dA6nIwjesfkZ7m1FKuIgICdXp+2aPIssLEEsvd/W4bDMkMpOP4uy7xM/uF2h0LJWcYMS4F3zAAAIABAACAAAAAgAEAAAAAAAAAIgIDB9SVgHpSdIaazXF9viZx8Nm+cjeHQOpyMI3rH5Ge5tQcsK9Y7TAAAIABAACAAAAAgAIAAIABAAAAAAAAAAA=';
+    // wallet used in this transaction
+    var parsed_desc = SpecterRust.parse_descriptor('wsh(sortedmulti(1,[b0af58ed/48h/1h/0h/2h]tpubDED6SSLLgFCtDZNQv1BBCoe15uw4ebin4eN3MFNmdLtynBaXNEfVzdkVjqBL2E4kUzCYyYzc7GVNf8vv9Luefpwh2DWXbQVt8ZtCXmes2Zk/0/*,[312e05df/48h/1h/0h]tpubDD5NnAHJkEri3WeR9QP2McFoHeFte3Y9ytQAYKs2TwASMk5XutLLREGB8XvinTvUUU1wD2nvrzEwcXBzsQ1XkFdCKXEpqwLCVf2FHVpGNDb/0/*))', root, 'regtest');
+    expect(parsed_desc['mine'], [false, true]);
+    var wallet = {
+      'recv_descriptor': parsed_desc['recv_descriptor'],
+      'change_descriptor': parsed_desc['change_descriptor'],
+    };
+    var res = SpecterRust.parse_transaction(psbt, [wallet], 'regtest');
+    // TODO: finish test
+  });
+
+  test('sign_transaction', () {
+    // TODO: more tests (legacy, nested segwit, single-sig, miniscript)
+    String root = 'xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm';
+    String psbt = 'cHNidP8BAH0CAAAAAfDz5mfHe0eBUAbazbcr7we9vpo2+hxiiWxGnPMkwLj+AAAAAAD+////AoCWmAAAAAAAFgAUM0kk6vRugG6Gs1N6EvgVlQMNc6fNSV0FAAAAACIAIPS/xbC8hbQfm15NlCSFLrdSVY0nsQIaJQ5X9R3zbefg1gAAAAABAH0CAAAAAcGtDHVoTFXHMZZJSA8zJ362P1ZLvmPuyhqdb7k6bOWbAAAAAAD+////AgDh9QUAAAAAIgAgjG8duakkjuNk3IzbiMKr91QjvUUtT2/1Li4LXzxgBPlnEBAkAQAAABYAFKBfKSQYEBYs5aYwucljg4mW0OsuAAAAAAEBKwDh9QUAAAAAIgAgjG8duakkjuNk3IzbiMKr91QjvUUtT2/1Li4LXzxgBPkBBUdRIQJd2kbjIJNo6aA3muoxjqa3bietbgN7lqrbjMbPzScO9iEDqYT05aiCopyrT5gt8oIc8sM/JXv9nFbBVL5GR10uiptSriIGAl3aRuMgk2jpoDea6jGOprduJ61uA3uWqtuMxs/NJw72HLCvWO0wAACAAQAAgAAAAIACAACAAAAAAAAAAAAiBgOphPTlqIKinKtPmC3yghzywz8le/2cVsFUvkZHXS6KmxgxLgXfMAAAgAEAAIAAAACAAAAAAAAAAAAAAAEBR1EhAnV6ftmjyLLCxBLL3f1uGwzJDKTj+Lsu8TP7hdodCyVnIQMH1JWAelJ0hprNcX2+JnHw2b5yN4dA6nIwjesfkZ7m1FKuIgICdXp+2aPIssLEEsvd/W4bDMkMpOP4uy7xM/uF2h0LJWcYMS4F3zAAAIABAACAAAAAgAEAAAAAAAAAIgIDB9SVgHpSdIaazXF9viZx8Nm+cjeHQOpyMI3rH5Ge5tQcsK9Y7TAAAIABAACAAAAAgAIAAIABAAAAAAAAAAA=';
+    String res = SpecterRust.sign_transaction(psbt, root);
+    expect(res, 'cHNidP8BAH0CAAAAAfDz5mfHe0eBUAbazbcr7we9vpo2+hxiiWxGnPMkwLj+AAAAAAD+////AoCWmAAAAAAAFgAUM0kk6vRugG6Gs1N6EvgVlQMNc6fNSV0FAAAAACIAIPS/xbC8hbQfm15NlCSFLrdSVY0nsQIaJQ5X9R3zbefg1gAAAAABAH0CAAAAAcGtDHVoTFXHMZZJSA8zJ362P1ZLvmPuyhqdb7k6bOWbAAAAAAD+////AgDh9QUAAAAAIgAgjG8duakkjuNk3IzbiMKr91QjvUUtT2/1Li4LXzxgBPlnEBAkAQAAABYAFKBfKSQYEBYs5aYwucljg4mW0OsuAAAAAAEBKwDh9QUAAAAAIgAgjG8duakkjuNk3IzbiMKr91QjvUUtT2/1Li4LXzxgBPkiAgOphPTlqIKinKtPmC3yghzywz8le/2cVsFUvkZHXS6Km0cwRAIgS0xgodv7JGCxUYVvuG7DRknWP9W+sEp++g2bMS/Vg2MCIGkf0WfEoeCVaisbg2thcU/gr80x25Iewr9QdYjTphFwAQEFR1EhAl3aRuMgk2jpoDea6jGOprduJ61uA3uWqtuMxs/NJw72IQOphPTlqIKinKtPmC3yghzywz8le/2cVsFUvkZHXS6Km1KuIgYCXdpG4yCTaOmgN5rqMY6mt24nrW4De5aq24zGz80nDvYcsK9Y7TAAAIABAACAAAAAgAIAAIAAAAAAAAAAACIGA6mE9OWogqKcq0+YLfKCHPLDPyV7/ZxWwVS+RkddLoqbGDEuBd8wAACAAQAAgAAAAIAAAAAAAAAAAAAAAQFHUSECdXp+2aPIssLEEsvd/W4bDMkMpOP4uy7xM/uF2h0LJWchAwfUlYB6UnSGms1xfb4mcfDZvnI3h0DqcjCN6x+RnubUUq4iAgJ1en7Zo8iywsQSy939bhsMyQyk4/i7LvEz+4XaHQslZxgxLgXfMAAAgAEAAIAAAACAAQAAAAAAAAAiAgMH1JWAelJ0hprNcX2+JnHw2b5yN4dA6nIwjesfkZ7m1Bywr1jtMAAAgAEAAIAAAACAAgAAgAEAAAAAAAAAAA==');
+  });
 
   test('greet', () {
     expect(SpecterRust.greet('Alice'), 'Hello Alice');

--- a/specter_rust/test/specter_rust_test.dart
+++ b/specter_rust/test/specter_rust_test.dart
@@ -2,6 +2,211 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:specter_rust/specter_rust.dart';
 
 void main() {
+  test('mnemonic_from_entropy', () {
+    // 12-word mnemonic
+    expect(
+      SpecterRust.mnemonic_from_entropy('31313131313131313131313131313131'),
+      'couple maze era give basic obtain shadow change couple maze era glide'
+    );
+    // 24-word mnemonic
+    expect(
+      SpecterRust.mnemonic_from_entropy('3131313131313131313131313131313131313131313131313131313131313131'),
+      'couple maze era give basic obtain shadow change couple maze era give basic obtain shadow change couple maze era give basic obtain shadow course'
+    );
+    // invalid hex - odd number of chars
+    expect(() => SpecterRust.mnemonic_from_entropy('3131313131313131313131313131313'), throwsException);
+    // invalid hex - invalid char
+    expect(() => SpecterRust.mnemonic_from_entropy('x3131313131313131313131313131313'), throwsException);
+    // invalid entropy - not 16 or 32 bytes
+    expect(() => SpecterRust.mnemonic_from_entropy('313131313131313131313131313131'), throwsException);
+  });
+
+  test('mnemonic_to_root_key', () {
+    // without a password
+    expect(
+      SpecterRust.mnemonic_to_root_key('couple maze era give basic obtain shadow change couple maze era glide', ''),
+      {'fingerprint': '312e05df', 'xprv': 'xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm' }
+    );
+    // with password
+    expect(
+      SpecterRust.mnemonic_to_root_key('couple maze era give basic obtain shadow change couple maze era glide', 'pa\$\$W0rd!'),
+      {'fingerprint': '2a264346', 'xprv': 'xprv9s21ZrQH143K4RxC4zgqydAA9w8aynyzGDGBe4C9FwhPhrz1M8fTVEvXy9vC9MQAixdSg3JPmv7nMgFcD2fCdaj5Y42uB5RidivFhHUJKMi' }
+    );
+    // invalid mnemonic
+    expect(() => SpecterRust.mnemonic_to_root_key('couple maze era give basic obtain shadow change couple maze era abandon', ''), throwsException);
+    // valid mnemonic with 15 words - should it fail??? Should we support 15 and 18-word mnemonics?
+    expect(() => SpecterRust.mnemonic_to_root_key('middle banner sunset more refuse icon add guess cruel nice replace clarify salad window way', ''), throwsException);
+  });
+
+  test('derive_xpub', () {
+    // with h for hardened
+    expect(
+      SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/84h/0h/0h', 'bitcoin'),
+      '[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H'
+    );
+    // with ' for hardened
+    expect(
+      SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', "m/84'/1'/0'", 'testnet'),
+      "[312e05df/84'/1'/0']tpubDDn2rtW7sBWSjWbvweMpLwi8t3er1cYy4o99SJ1osrWULjvPG2XS9HQm55haCmxp5UhVtmFSdE8qhfyNgBZvqzMKj3CR8NF8yAwbTeji8jN"
+    );
+    // with tprv as root
+    expect(
+      SpecterRust.derive_xpub('tprv8ZgxMBicQKsPews2wvq5dsfyJHWXiaPkfXoMuLDPCLD8dL7DMG1GxeTxWXBowVs73iRMAbrQFSUouMA8KB9JNPrTwB9Q1idcMeG1T5BbVWQ', 'm/84h/0h/0h', 'bitcoin'),
+      '[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H'
+    );
+    // with non-hardened derivation
+    expect(
+      SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/0/1/2', 'bitcoin'),
+      '[312e05df/0/1/2]xpub6CQXxMG5hw7Dj4LoEGmkKeGBaTKWxEMG3wn8otDVAWrxEwBsyBBEK5ZckeCRqbjJb7b8JC3Yknodi6HwNcAoeisrYH7ASRVDsaAPNpUgyPZ'
+    );
+    // with empty derivation
+    expect(
+      SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm', 'testnet'),
+      '[312e05df]tpubD6NzVbkrYhZ4YQtpqaVg3HL5sK2TsuafEqQ9BrFgcc1XTpMyyeps995pgg4E3kL71eY2dPC9sbs3cETeG9AMjzwYFqfHhh4mL2dxnNZwgSJ'
+    );
+    // invalid derivation - invalid char
+    expect(() => SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/1f/2', 'testnet'), throwsException);
+    // invalid derivation - trailing slash
+    expect(() => SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/1/2/', 'testnet'), throwsException);
+    // invalid derivation - missing m/
+    expect(() => SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', '1/2', 'testnet'), throwsException);
+    // invalid network
+    expect(() => SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/1', 'unknown'), throwsException);
+    // invalid xprv
+    expect(() => SpecterRust.derive_xpub('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZ', 'm/1', 'bitcoin'), throwsException);
+  });
+
+  test('get_descriptors', () {
+    // segwit
+    expect(
+      SpecterRust.get_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/84h/0h/0h', 'segwit', 'bitcoin'),
+      {
+        'recv_descriptor': "wpkh([312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*)#sdm5z7jr",
+        'change_descriptor': "wpkh([312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/1/*)#pe74ltzm",
+      }
+    );
+    // nested, testnet, non-standard path
+    expect(
+      SpecterRust.get_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/48h/1h/0h', 'nested', 'testnet'),
+      {
+        'recv_descriptor': "sh(wpkh([312e05df/48'/1'/0']tpubDD5NnAHJkEri3WeR9QP2McFoHeFte3Y9ytQAYKs2TwASMk5XutLLREGB8XvinTvUUU1wD2nvrzEwcXBzsQ1XkFdCKXEpqwLCVf2FHVpGNDb/0/*))#5ylsl677",
+        'change_descriptor': "sh(wpkh([312e05df/48'/1'/0']tpubDD5NnAHJkEri3WeR9QP2McFoHeFte3Y9ytQAYKs2TwASMk5XutLLREGB8XvinTvUUU1wD2nvrzEwcXBzsQ1XkFdCKXEpqwLCVf2FHVpGNDb/1/*))#p93x89tp",
+      }
+    );
+    // legacy
+    expect(
+      SpecterRust.get_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/44h/0h/0h', 'legacy', 'bitcoin'),
+      {
+        'recv_descriptor': "pkh([312e05df/44'/0'/0']xpub6CS6bnU3Z51mzCvMDgggeyCNQ8XT1dArAJwoZn51FaNTFQm9xDCTzFt7zqUPe61sqLMUEWCbFHdNA4cExrzDi5aMZJ7tEcCy4X8SJrovF3X/0/*)#tae43hru",
+        'change_descriptor': "pkh([312e05df/44'/0'/0']xpub6CS6bnU3Z51mzCvMDgggeyCNQ8XT1dArAJwoZn51FaNTFQm9xDCTzFt7zqUPe61sqLMUEWCbFHdNA4cExrzDi5aMZJ7tEcCy4X8SJrovF3X/1/*)#6fu5vzny",
+      }
+    );
+    // unknown type
+    expect(() => SpecterRust.get_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'm/44h/0h/0h', 'raw', 'bitcoin'), throwsException);
+  });
+
+  test('get_default_descriptors', () {
+    // mainnet
+    expect(
+      SpecterRust.get_default_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'bitcoin'),
+      {
+        'recv_descriptor': "wpkh([312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*)#sdm5z7jr",
+        'change_descriptor': "wpkh([312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/1/*)#pe74ltzm",
+      }
+    );
+    // testnet (signet)
+    expect(
+      SpecterRust.get_default_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 'signet'),
+      {
+        'recv_descriptor': "wpkh([312e05df/84'/1'/0']tpubDDn2rtW7sBWSjWbvweMpLwi8t3er1cYy4o99SJ1osrWULjvPG2XS9HQm55haCmxp5UhVtmFSdE8qhfyNgBZvqzMKj3CR8NF8yAwbTeji8jN/0/*)#lcggctks",
+        'change_descriptor': "wpkh([312e05df/84'/1'/0']tpubDDn2rtW7sBWSjWbvweMpLwi8t3er1cYy4o99SJ1osrWULjvPG2XS9HQm55haCmxp5UhVtmFSdE8qhfyNgBZvqzMKj3CR8NF8yAwbTeji8jN/1/*)#wvdf97xg",
+      }
+    );
+  });
+
+  test('get_account_descriptors', () {
+    // mainnet account 2
+    expect(
+      SpecterRust.get_account_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 2, 'segwit', 'bitcoin'),
+      {
+        'recv_descriptor': "wpkh([312e05df/84'/0'/2']xpub6CXXH6KkmqEb1Dfr9Xwpo1B8RMShGbaSnYkbc8vMBHiPXRMCMGNJhFQF28ks7Xkp4PQBZ7TxLfu1kTwQBMgkxXdm3UdUpnunKhbkKvmYbjA/0/*)#n8ts2ytd",
+        'change_descriptor': "wpkh([312e05df/84'/0'/2']xpub6CXXH6KkmqEb1Dfr9Xwpo1B8RMShGbaSnYkbc8vMBHiPXRMCMGNJhFQF28ks7Xkp4PQBZ7TxLfu1kTwQBMgkxXdm3UdUpnunKhbkKvmYbjA/1/*)#znw3h3m4",
+      }
+    );
+    // testnet (signet) nested, account 3
+    expect(
+      SpecterRust.get_account_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 3, 'nested', 'signet'),
+      {
+        'recv_descriptor': "sh(wpkh([312e05df/49'/1'/3']tpubDCwzf87ASQN62T68j8SR5LtRp4X2rK1r8U6yKBwvwA9fQmRbMmKx4RMmWcDhD2RTHSHxCXCacbKDiasqTzNGGvaHGkL6VZCKL9GjDnmbqez/0/*))#68l8lqpv",
+        'change_descriptor': "sh(wpkh([312e05df/49'/1'/3']tpubDCwzf87ASQN62T68j8SR5LtRp4X2rK1r8U6yKBwvwA9fQmRbMmKx4RMmWcDhD2RTHSHxCXCacbKDiasqTzNGGvaHGkL6VZCKL9GjDnmbqez/1/*))#0x338l5n",
+      }
+    );
+    // account at max index
+    expect(
+      SpecterRust.get_account_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 2147483647, 'segwit', 'bitcoin'),
+      {
+        'recv_descriptor': "wpkh([312e05df/84'/0'/2147483647']xpub6CXXH6Ku7VmZ2wZ2DByEt8gDUxnt6wEbV74ydiaGhdKi6qMtatSyeLSQECpL5NrSDiATYwgCXQ6WEQUcdM1bg6rL8ZwCZX3LDJiQTcWRc3T/0/*)#p557e237",
+        'change_descriptor': "wpkh([312e05df/84'/0'/2147483647']xpub6CXXH6Ku7VmZ2wZ2DByEt8gDUxnt6wEbV74ydiaGhdKi6qMtatSyeLSQECpL5NrSDiATYwgCXQ6WEQUcdM1bg6rL8ZwCZX3LDJiQTcWRc3T/1/*)#sq3lylpx",
+      }
+    );
+    // negative account number
+    expect( () => SpecterRust.get_account_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', -3, 'nested', 'signet'), throwsException);
+    // account larger than 0x80000000-1 ( 2147483647 )
+    expect( () => SpecterRust.get_account_descriptors('xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm', 2147483648, 'nested', 'signet'), throwsException);
+  });
+
+  test('derive_addresses', () {
+    // mainnet addresses
+    expect(
+      SpecterRust.derive_addresses(
+        "wpkh([312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*)#sdm5z7jr",
+        'bitcoin', 0, 10),
+      [
+        'bc1qx50sxylvwlpz32qjknld6twag2apqhvf5n3n2w',
+        'bc1q3eyxm4q3m2nuycgfex9myc6x2rx4mxqc95rj4x',
+        'bc1qujypaultffwyqp37pjkfelnm6ka5jseh2xt0d8',
+        'bc1qwsefpmme345afvxwhny7tr7k33khgx3qw36zew',
+        'bc1qavmyd0shjndwfv92ttf559dfks0pcws35yhsw6',
+        'bc1qmkwpnr3psswd4qf8002tufdcytkf6zg8e7xq44',
+        'bc1qxf4e8vhqxrdedn6l43rsgh3jrygufxatnsll5k',
+        'bc1qtn0q7y6p4klplgpzfj3av8lnmw2rf0anls2wjh',
+        'bc1quwua82dm46td2jhrnjwp8x45l02ey0ysk573f8',
+        'bc1qz3eckwuufvgv40t3nftm9rkstkq8mwp5jzfhud',
+      ]
+    );
+    // regtest - should it raise if xpubs are used?
+    expect(
+      SpecterRust.derive_addresses(
+        "wpkh([312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*)#sdm5z7jr",
+        'regtest', 3, 5),
+      ['bcrt1qwsefpmme345afvxwhny7tr7k33khgx3qx7cu45', 'bcrt1qavmyd0shjndwfv92ttf559dfks0pcws3ut4wzq']
+    );
+    // nested
+    expect(
+      SpecterRust.derive_addresses(
+        "sh(wpkh([312e05df/49'/1'/3']tpubDCwzf87ASQN62T68j8SR5LtRp4X2rK1r8U6yKBwvwA9fQmRbMmKx4RMmWcDhD2RTHSHxCXCacbKDiasqTzNGGvaHGkL6VZCKL9GjDnmbqez/1/*))#0x338l5n",
+        'regtest', 3, 5),
+      ['2Mt1tSaRL4oPm3iTdL8YRLpqCqM22SVVuHr', '2N3SGwaDrTPyn21srqSRPXCEkEZMSmdZaBK']
+    );
+    // start > end - empty arr
+    expect(
+      SpecterRust.derive_addresses("sh(wpkh([312e05df/49'/1'/3']tpubDCwzf87ASQN62T68j8SR5LtRp4X2rK1r8U6yKBwvwA9fQmRbMmKx4RMmWcDhD2RTHSHxCXCacbKDiasqTzNGGvaHGkL6VZCKL9GjDnmbqez/1/*))#0x338l5n", 'regtest', 5, 3),
+      []
+    );
+    // invalid index - negative
+    expect(()=> SpecterRust.derive_addresses("sh(wpkh([312e05df/49'/1'/3']tpubDCwzf87ASQN62T68j8SR5LtRp4X2rK1r8U6yKBwvwA9fQmRbMmKx4RMmWcDhD2RTHSHxCXCacbKDiasqTzNGGvaHGkL6VZCKL9GjDnmbqez/1/*))#0x338l5n", 'regtest', -1, 3), throwsException);
+    expect(()=> SpecterRust.derive_addresses("sh(wpkh([312e05df/49'/1'/3']tpubDCwzf87ASQN62T68j8SR5LtRp4X2rK1r8U6yKBwvwA9fQmRbMmKx4RMmWcDhD2RTHSHxCXCacbKDiasqTzNGGvaHGkL6VZCKL9GjDnmbqez/1/*))#0x338l5n", 'regtest', 0, 0x80000000), throwsException);
+    // check it can derive 1000 addresses
+    expect(
+      SpecterRust.derive_addresses("sh(wpkh([312e05df/49'/1'/3']tpubDCwzf87ASQN62T68j8SR5LtRp4X2rK1r8U6yKBwvwA9fQmRbMmKx4RMmWcDhD2RTHSHxCXCacbKDiasqTzNGGvaHGkL6VZCKL9GjDnmbqez/1/*))#0x338l5n", 'regtest', 0, 1000).length,
+      1000
+    );
+  });
+
+  // TODO: parse_descriptor
+  // TODO: parse_transaction
+  // TODO: sign_transaction
+
   test('greet', () {
     expect(SpecterRust.greet('Alice'), 'Hello Alice');
   });

--- a/specter_rust/test/specter_rust_test.dart
+++ b/specter_rust/test/specter_rust_test.dart
@@ -232,6 +232,11 @@ void main() {
       SpecterRust.parse_descriptor("wsh(sortedmulti(1,[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/<0;1>/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/<0;1>/*))", root, 'bitcoin'),
       expected
     );
+    // test without derivation at all - should add derivations automatically
+    expect(
+      SpecterRust.parse_descriptor("wsh(sortedmulti(1,[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq))", root, 'bitcoin'),
+      expected
+    );
   });
 
   test('parse_transaction', () {

--- a/specter_rust/test/specter_rust_test.dart
+++ b/specter_rust/test/specter_rust_test.dart
@@ -203,7 +203,24 @@ void main() {
     );
   });
 
-  // TODO: parse_descriptor
+  test('parse_descriptor', () {
+    String root = 'xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm';
+    expect(
+      SpecterRust.parse_descriptor("wsh(sortedmulti(1,[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/0/*))", root, 'bitcoin'),
+      {
+        'recv_descriptor': "wsh(sortedmulti(1,[312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/0/*))#0ahjda52",
+        'change_descriptor': "wsh(sortedmulti(1,[312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/1/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/1/*))#x4lq90gh",
+        'keys': [
+          "[312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*",
+          "[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/0/*",
+        ],
+        'mine': [true, false],
+        'type': 'segwit',
+        'policy': '1 of 2 multisig',
+      }
+    );
+    // TODO: more tests
+  });
   // TODO: parse_transaction
   // TODO: sign_transaction
 

--- a/specter_rust/test/specter_rust_test.dart
+++ b/specter_rust/test/specter_rust_test.dart
@@ -246,7 +246,28 @@ void main() {
       'change_descriptor': parsed_desc['change_descriptor'],
     };
     var res = SpecterRust.parse_transaction(psbt, [wallet], 'regtest');
-    // TODO: finish test
+    expect(res, {
+      'inputs': [
+        {
+          'address': 'bcrt1q33h3mwdfyj8wxexu3ndc3s4t7a2z8029948klafw9c9470rqqnusayrnw4',
+          'value': 100000000,
+          'wallets': [0],
+        }
+      ],
+      'outputs': [
+        {
+          'address': 'bcrt1qxdyjf6h5d6qxap4n2dap97q4j5ps6ua8jkxz0z',
+          'value': 10000000,
+          'wallets': []
+        },
+        {
+          'address': 'bcrt1q7jlutv9usk6plx67fk2zfpfwkaf9trf8kypp5fgw2l63mumdulsqvpnqt3',
+          'value': 89999821,
+          'wallets': [0]
+        },
+      ],
+      'fee': 179,
+    });
   });
 
   test('sign_transaction', () {

--- a/specter_rust/test/specter_rust_test.dart
+++ b/specter_rust/test/specter_rust_test.dart
@@ -206,19 +206,31 @@ void main() {
   test('parse_descriptor', () {
     // TODO: more tests
     String root = 'xprv9s21ZrQH143K48dWHMyaUE3yzA6KV4MkKytF2unviMieqjN8MtfXSu6WbM29w8UngGtaAWEe65u1SVcPBxoMZLasQXw6MMuZSYWb1QDAbZm';
+    var expected = {
+      'recv_descriptor': "wsh(sortedmulti(1,[312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/0/*))#0ahjda52",
+      'change_descriptor': "wsh(sortedmulti(1,[312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/1/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/1/*))#x4lq90gh",
+      'keys': [
+        "[312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*",
+        "[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/0/*",
+      ],
+      'mine': [true, false],
+      'type': 'segwit',
+      'policy': '1 of 2 multisig',
+    };
+    // test with /0/*
     expect(
       SpecterRust.parse_descriptor("wsh(sortedmulti(1,[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/0/*))", root, 'bitcoin'),
-      {
-        'recv_descriptor': "wsh(sortedmulti(1,[312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/0/*))#0ahjda52",
-        'change_descriptor': "wsh(sortedmulti(1,[312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/1/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/1/*))#x4lq90gh",
-        'keys': [
-          "[312e05df/84'/0'/0']xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/0/*",
-          "[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/0/*",
-        ],
-        'mine': [true, false],
-        'type': 'segwit',
-        'policy': '1 of 2 multisig',
-      }
+      expected
+    );
+    // test with /{0,1}/*
+    expect(
+      SpecterRust.parse_descriptor("wsh(sortedmulti(1,[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/{0,1}/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/{0,1}/*))", root, 'bitcoin'),
+      expected
+    );
+    // test with /<0;1>/*
+    expect(
+      SpecterRust.parse_descriptor("wsh(sortedmulti(1,[312e05df/84h/0h/0h]xpub6CXXH6KkmqEavpf5svtvJe1aXWHeBCRVgnQ1qf4ZekwjYGmXAAsxhmJ3rYnq8qfqnWFVcti42yqi6SqNahsTmpizzvxefP7N5GXyhwPZc3H/<0;1>/*,[12345678/49'/1'/3']xpub6EpqBFyJW2qiEmgcYZqwEGCRuQh3y9fY72RWeAG7pNvKJWgnx7mkviWtfsF7VNQhWPx43zzNfkWhoF8RcnP2KKsXbNHrFNdzx8MFy83N5Sq/<0;1>/*))", root, 'bitcoin'),
+      expected
     );
   });
 


### PR DESCRIPTION
MVP for the rust part:
- `parse_descriptor` function parses a descriptor received from the host and returns metadata for display to the user - what is the wallet policy (M of N multiisig), script type, keys involved in the descriptor, which keys are derived from root, recv and change descriptors in the canonical form.
- `parse_transaction` function - parses base64-encoded psbt transaction and returns metadata about each input and output.
- `sign_transaction` function - signs a transaction with the root key

Also added tests for the rust part.

The API and returned data for `parse_***` functions may change in the future but current implementation is already enough to get minimal functionality in the app.